### PR TITLE
Allow pcie_tlp_demux_bar to demux on BAR ID 6 (Option ROM)

### DIFF
--- a/rtl/pcie_tlp_demux_bar.v
+++ b/rtl/pcie_tlp_demux_bar.v
@@ -127,7 +127,7 @@ integer i, j;
 // check configuration
 initial begin
     for (i = 0; i < PORTS; i = i + 1) begin
-        if (BAR_IDS_INT[i*3 +: 3] > 5) begin
+        if (BAR_IDS_INT[i*3 +: 3] > 6) begin
             $error("Error: BAR out of range (instance %m)");
             $finish;
         end


### PR DESCRIPTION
The Expansion ROM (PCI Option ROM) BAR is index 6. Allowing BAR_IDS to specify BAR 6 in pcie_tlp_demux_bar allows TLPs targeting the Expansion ROM BAR to be demuxed and handled by the user design.