### PR TITLE
Add explicit python3 prefix to all python paths in test suite

### DIFF
--- a/tb/pcie_tlp_demux/Makefile
+++ b/tb/pcie_tlp_demux/Makefile
@@ -70,7 +70,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/pcie_tlp_demux/test_pcie_tlp_demux.py
+++ b/tb/pcie_tlp_demux/test_pcie_tlp_demux.py
@@ -261,7 +261,7 @@ def test_pcie_tlp_demux(request, pcie_data_width, tlp_seg_count, ports):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/pcie_tlp_demux_bar/Makefile
+++ b/tb/pcie_tlp_demux_bar/Makefile
@@ -74,7 +74,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/pcie_tlp_demux_bar/test_pcie_tlp_demux_bar.py
+++ b/tb/pcie_tlp_demux_bar/test_pcie_tlp_demux_bar.py
@@ -251,7 +251,7 @@ def test_pcie_tlp_demux_bar(request, pcie_data_width, tlp_seg_count, ports):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/pcie_tlp_fifo_mux/Makefile
+++ b/tb/pcie_tlp_fifo_mux/Makefile
@@ -71,7 +71,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/pcie_tlp_fifo_mux/test_pcie_tlp_fifo_mux.py
+++ b/tb/pcie_tlp_fifo_mux/test_pcie_tlp_fifo_mux.py
@@ -248,7 +248,7 @@ def test_pcie_tlp_fifo_mux(request, pcie_data_width, tlp_seg_count, ports, round
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/pcie_tlp_mux/Makefile
+++ b/tb/pcie_tlp_mux/Makefile
@@ -66,7 +66,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/pcie_tlp_mux/test_pcie_tlp_mux.py
+++ b/tb/pcie_tlp_mux/test_pcie_tlp_mux.py
@@ -248,7 +248,7 @@ def test_pcie_tlp_mux(request, pcie_data_width, tlp_seg_count, ports, round_robi
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 


### PR DESCRIPTION
Allows WSL to properly execute the tests by explicitly stating how the python files should execute. Line ending issues cause WSL to get confused if the repo uses Windows line endings.